### PR TITLE
Remove Strict Severity & Improve Code Structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "maplephp/blunder",
   "type": "library",
-  "version": "v1.2.0",
+  "version": "v1.2.1",
   "description": "Blunder is a well-designed PHP error handling framework.",
   "keywords": [
     "php",

--- a/src/ExceptionItem.php
+++ b/src/ExceptionItem.php
@@ -120,7 +120,7 @@ class ExceptionItem
             E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, 0 => "error",
             E_WARNING, E_USER_WARNING, E_COMPILE_WARNING => "warning",
             E_NOTICE, E_USER_NOTICE => "notice",
-            E_STRICT, E_DEPRECATED, E_USER_DEPRECATED => "info",
+            E_DEPRECATED, E_USER_DEPRECATED => "info",
             default => "debug",
         };
 

--- a/src/Handlers/HtmlHandler.php
+++ b/src/Handlers/HtmlHandler.php
@@ -13,7 +13,7 @@ use ErrorException;
 use MaplePHP\Blunder\Interfaces\HandlerInterface;
 use Throwable;
 
-class HtmlHandler extends AbstractAbstractHandler implements HandlerInterface
+class HtmlHandler extends AbstractHandler implements HandlerInterface
 {
     /** @var string */
     public const CSS_FILE = 'main.css';
@@ -21,6 +21,11 @@ class HtmlHandler extends AbstractAbstractHandler implements HandlerInterface
     public const JS_FILE = 'main.js';
 
     protected static bool $enabledTraceLines = true;
+
+    public function testssss($www1)
+    {
+        return "Lorem1";
+    }
 
     /**
      * Exception handler output

--- a/src/Handlers/JsonHandler.php
+++ b/src/Handlers/JsonHandler.php
@@ -13,7 +13,7 @@ use MaplePHP\Blunder\ExceptionItem;
 use MaplePHP\Blunder\Interfaces\HandlerInterface;
 use Throwable;
 
-class JsonHandler extends AbstractAbstractHandler implements HandlerInterface
+class JsonHandler extends AbstractHandler implements HandlerInterface
 {
     protected static bool $enabledTraceLines = true;
 

--- a/src/Handlers/TextHandler.php
+++ b/src/Handlers/TextHandler.php
@@ -13,7 +13,7 @@ use MaplePHP\Blunder\Interfaces\HandlerInterface;
 use MaplePHP\Blunder\SeverityLevelPool;
 use Throwable;
 
-class TextHandler extends AbstractAbstractHandler implements HandlerInterface
+class TextHandler extends AbstractHandler implements HandlerInterface
 {
     protected static bool $enabledTraceLines = true;
 

--- a/src/Handlers/XmlHandler.php
+++ b/src/Handlers/XmlHandler.php
@@ -14,7 +14,7 @@ use MaplePHP\Blunder\Interfaces\HandlerInterface;
 use SimpleXMLElement;
 use Throwable;
 
-class XmlHandler extends AbstractAbstractHandler implements HandlerInterface
+class XmlHandler extends AbstractHandler implements HandlerInterface
 {
     protected static bool $enabledTraceLines = true;
 

--- a/src/SeverityLevelPool.php
+++ b/src/SeverityLevelPool.php
@@ -28,7 +28,6 @@ class SeverityLevelPool
         E_USER_ERROR => 'E_USER_ERROR',
         E_USER_WARNING => 'E_USER_WARNING',
         E_USER_NOTICE => 'E_USER_NOTICE',
-        E_STRICT => 'E_STRICT',
         E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
         E_DEPRECATED => 'E_DEPRECATED',
         E_USER_DEPRECATED => 'E_USER_DEPRECATED',

--- a/tests/unitary-blunder-event.php
+++ b/tests/unitary-blunder-event.php
@@ -14,7 +14,7 @@ use MaplePHP\Unitary\Unit;
 
 $unit = new Unit();
 
-$unit->case("MaplePHP pretty error handler test", function ($inst) {
+$unit->case("MaplePHP Blunder event test", function ($inst) {
 
     // SilentHandler will hide the error that I have added in this file
     // and is using to test the Blunder library

--- a/tests/unitary-blunder-handlers.php
+++ b/tests/unitary-blunder-handlers.php
@@ -1,0 +1,81 @@
+#!/usr/bin/env php
+<?php
+/**
+ * This is how a template test file should look like but
+ * when used in MaplePHP framework you can skip the "bash code" at top and the "autoload file"!
+ */
+
+use MaplePHP\Blunder\ExceptionItem;
+use MaplePHP\Blunder\Handlers\CliHandler;
+use MaplePHP\Blunder\Handlers\HtmlHandler;
+use MaplePHP\Blunder\Handlers\JsonHandler;
+use MaplePHP\Blunder\Handlers\PlainTextHandler;
+use MaplePHP\Blunder\Handlers\SilentHandler;
+use MaplePHP\Blunder\Handlers\TextHandler;
+use MaplePHP\Blunder\Handlers\XmlHandler;
+use MaplePHP\Blunder\Interfaces\HandlerInterface;
+use MaplePHP\Blunder\Run;
+use MaplePHP\Unitary\TestWrapper;
+use MaplePHP\Unitary\Unit;
+
+// If you add true to Unit it will run in quite mode
+// and only report if it finds any errors!
+
+
+$unit = new Unit();
+
+$unit->case("MaplePHP Blunder handler test", function ($inst) {
+
+    // SilentHandler will hide the error that I have added in this file
+    // and is using to test the Blunder library
+
+    $run = new Run(new SilentHandler());
+    $run->severity()
+        ->excludeSeverityLevels([E_WARNING, E_USER_WARNING])
+        ->redirectTo(function ($errNo, $errStr, $errFile, $errLine) use ($inst) {
+
+            $func = function (string $className) {
+                $dispatch = $this->wrapper($className)->bind(function ($exception) {
+                    $this->setExitCode(null);
+                    ob_start();
+                    $this->exceptionHandler($exception);
+                    return ob_get_clean();
+                });
+                return $dispatch(new Exception("Mock exception"));
+            };;
+
+            $inst->add($func(HtmlHandler::class), [
+                'length' => 100,
+                'isFullHtml' => true
+            ], "HtmlHandler do not return a valid HTML string");
+
+            $inst->add($func(JsonHandler::class), [
+                'length' => 100,
+                'isJson' => true
+            ], "JsonHandler do not return a valid JSON string");
+
+            $inst->add($func(TextHandler::class), [
+                'length' => [10],
+            ], "TextHandler do not return a valid CLI string");
+
+            $inst->add($func(PlainTextHandler::class), [
+                'length' => [10],
+            ], "PlainTextHandler do not return a valid CLI string");
+
+            $inst->add($func(XmlHandler::class), [
+                'length' => [10],
+            ], "CliHandler do not return a valid CLI string");
+
+            $inst->add($func(CliHandler::class), [
+                'length' => [1],
+            ], "CliHandler do not return a valid CLI string");
+
+            return true;
+        });
+    $run->load();
+
+    // Mock error
+    echo $helloWorld;
+});
+
+$unit->execute();

--- a/tests/unitary-blunder-redirect.php
+++ b/tests/unitary-blunder-redirect.php
@@ -1,0 +1,45 @@
+#!/usr/bin/env php
+<?php
+/**
+ * This is how a template test file should look like but
+ * when used in MaplePHP framework you can skip the "bash code" at top and the "autoload file"!
+ */
+
+use MaplePHP\Blunder\Handlers\SilentHandler;
+use MaplePHP\Blunder\Run;
+use MaplePHP\Unitary\Unit;
+
+// If you add true to Unit it will run in quite mode
+// and only report if it finds any errors!
+
+$unit = new Unit();
+
+$unit->case("MaplePHP Blunder redirect test", function ($inst) {
+
+    // SilentHandler will hide the error that I have added in this file
+    // and is using to test the Blunder library
+    $run = new Run(new SilentHandler());
+    $run->severity()
+        ->excludeSeverityLevels([E_WARNING, E_USER_WARNING])
+        ->redirectTo(function ($errNo, $errStr, $errFile, $errLine) use ($inst) {
+            $inst->add($errNo, [
+                'equal' => 2
+            ]);
+
+            $inst->add($errStr, [
+                'equal' => 'Undefined variable $helloWorld'
+            ]);
+
+            $inst->add(basename($errFile), [
+                'equal' => 'unitary-blunder-redirect.php'
+            ]);
+
+            $inst->add(basename($errLine), [
+                'isInt' => true
+            ]);
+        });
+    $run->load();
+    echo $helloWorld;
+});
+
+$unit->execute();


### PR DESCRIPTION
### **Summary**  
This PR includes the following improvements:  
- 🛠 **Minor structure improvements** – Enhances code organization for better readability and maintainability.  
- ❌ **Remove strict severity** – Strict severity is no longer needed and has been deprecated.  
- ✅ **Add more tests** – Expands test coverage to improve reliability and catch potential issues.  

### **Why?**  
- The strict severity level is deprecated and no longer necessary.  
- Structural adjustments help maintain cleaner and more efficient code.  
- Additional tests enhance stability and ensure expected behavior.  